### PR TITLE
Multiple targets

### DIFF
--- a/lib/dicebag.rb
+++ b/lib/dicebag.rb
@@ -109,7 +109,7 @@ module DiceBag
       normalize_reroll hash
       normalize_explode_indefinite hash
       normalize_drop_keep hash
-      normalize_target hash
+      normalize_targets hash
       normalize_failure hash
     end
 
@@ -197,16 +197,12 @@ module DiceBag
   # the dice sides and greater than 0,
   # otherwise, set it to 0 (aka no target
   # number) and add a note.
-  def self.normalize_target(hash)
-    return unless hash[:options].key? :target
+  def self.normalize_targets(hash)
+    return unless hash[:options].key? :targets
 
-    target = hash[:options][:target]
+    targets = hash[:options][:targets]
 
-    return if target >= 0 && target <= hash[:sides]
-
-    hash[:options][:target] = 0
-
-    hash[:notes].push 'Target number too large or is negative; reset to 0.'
+    hash[:options][:targets] = targets.select{ |target| target >= 0 && target <= hash[:sides] }
   end
 
   # This is the wrapper for the parse, transform,

--- a/lib/dicebag.rb
+++ b/lib/dicebag.rb
@@ -192,17 +192,24 @@ module DiceBag
     hash[:notes].push 'Failure number too large or is negative; reset to 0.'
   end
 
-  # Finally, if we have a target number,
-  # make sure it is equal to or less than
+  # Finally, if we have target numbers
+  # make sure they are equal to or less than
   # the dice sides and greater than 0,
-  # otherwise, set it to 0 (aka no target
-  # number) and add a note.
+  # otherwise, drop it.
   def self.normalize_targets(hash)
     return unless hash[:options].key? :targets
 
-    targets = hash[:options][:targets]
+    targets = []
 
-    hash[:options][:targets] = targets.select{ |target| target >= 0 && target <= hash[:sides] }
+    hash[:options][:targets].each do |target|    
+      if target >= 0 && target <= hash[:sides]
+        targets.push target
+      else
+        hash[:notes].push "Target number (#{target}) too large or less than 1; removed."
+      end
+    end
+  
+    hash[:options][:targets] = targets
   end
 
   # This is the wrapper for the parse, transform,

--- a/lib/dicebag/roll_part.rb
+++ b/lib/dicebag/roll_part.rb
@@ -24,7 +24,7 @@ module DiceBag
 
       # Our Default Options
       
-      @options = { explode: 0, explode_indefinite: 0, drop: 0, keep: 0, keeplowest: 0, reroll: 0, reroll_indefinite: 0, target: 0, failure: 0, botch: 0 }
+      @options = { explode: 0, explode_indefinite: 0, drop: 0, keep: 0, keeplowest: 0, reroll: 0, reroll_indefinite: 0, targets: [], failure: 0, botch: 0 }
 
       @options.update(part[:options]) if part.key?(:options)
     end
@@ -198,9 +198,9 @@ module DiceBag
       # in the results are >= than this number and subtract
       # the number <= the failure threshold, otherwise
       # we just add up all the numbers.
-      @total = if (@options[:target] || @options[:failure]) && ( @options[:target] > 0 || @options[:failure] > 0 )
-                 if @options[:target] && @options[:target] > 0
-                   @results.count {|r| r >= @options[:target] } - @results.count { |r| r <= @options[:failure] }
+      @total = if (@options[:targets] || @options[:failure]) && ( @options[:targets].length > 0 || @options[:failure] > 0 )
+                 if @options[:targets] && @options[:targets].length > 0
+                    @options[:targets].map{ |target| @results.count {|r| r >= target } - @results.count { |r| r <= @options[:failure] }  }.sum
                  else
                    0 - @results.count { |r| r <= @options[:failure] }
                  end 

--- a/lib/dicebag/roll_part_string.rb
+++ b/lib/dicebag/roll_part_string.rb
@@ -82,9 +82,7 @@ module RollPartString
   end
 
   def to_s_target
-    return if @options[:target].zero?
-
-    @parts.push format('t%s', @options[:target])
+    @options[:targets].each{ |target| @parts.push format('t%s', target) }
   end
 
   def to_s_failure

--- a/lib/dicebag/transform.rb
+++ b/lib/dicebag/transform.rb
@@ -9,8 +9,12 @@ module DiceBag
     def self.hashify_options(options)
       opts = {}
 
-      options.each { |val| opts.update val } if options.respond_to? :each
-
+      if options.respond_to? :each
+        options.reject{ |o| o.key?(:target) }.each { |val| opts.update val } 
+        targets = { targets: options.select{ |o| o.key?(:target) }.map{ |o| o[:target] } }
+        opts.update targets
+      end
+      
       opts
     end
 
@@ -23,6 +27,7 @@ module DiceBag
     rule(reroll:  simple(:x)) { { reroll: Integer(x) } }
     rule(reroll_indefinite:  simple(:x)) { { reroll_indefinite: Integer(x) } }
     rule(target:  simple(:x)) { { target: Integer(x) } }
+
     rule(failure: simple(:x)) { { failure: Integer(x) } }
     rule(botch:   simple(:x)) { { botch: Integer(x) } }
 

--- a/readme.md
+++ b/readme.md
@@ -109,7 +109,10 @@ the target number is added to a total of successes. For example, '5d10
 t8' means roll five 10-sided dice and each die that is 8 or higher is a
 success. (Similar to WhiteWolf games.) If this option is given a 0 value,
 that is the same as not having the option at all; that is, a normal sum
-of all dice in the roll is performed instead. 
+of all dice in the roll is performed instead.  This can be specified more
+than once and each dice will be counted the number of targets it matches.
+ie: "6d10 t7 t10" will give you a count of each 7 or above counting any 
+10s twice.
 
 **f#** - this denotes a failure number that each dice must match or be
 beneath in order to count against successes. These work as a sort of 

--- a/test/roll_part.rb
+++ b/test/roll_part.rb
@@ -139,6 +139,20 @@ describe DiceBag::RollPart do
       end
     end
 
+    describe 'with no options and two targets' do
+      before do
+        @part = xdx('3d6 t4 t6').first.last
+
+        make_not_so_random!
+
+        @part.roll
+      end
+
+      it 'should have a total of 3' do
+        _(@part.total).must_equal 3
+      end
+    end
+
     describe 'with an exploding option' do
       before do
         @part = xdx('3d6 e1 t4').first.last

--- a/test/roll_part_string.rb
+++ b/test/roll_part_string.rb
@@ -1,7 +1,7 @@
 # Encoding: UTF-8
 
 describe RollPartString do
-  ROLL_PART_DSTR = '4d6 d1 k1 r2 t4'.freeze
+  ROLL_PART_DSTR = '4d6 d1 k1 r2 t4 t6'.freeze
 
   before do
     @part = xdx(ROLL_PART_DSTR).first.last

--- a/test/roll_string.rb
+++ b/test/roll_string.rb
@@ -1,7 +1,7 @@
 # Encoding: UTF-8
 
 describe RollString do
-  ROLL_DSTR = '(Test) 4d6 d1 k1 r2 t4'.freeze
+  ROLL_DSTR = '(Test) 4d6 d1 k1 r2 t4 t6'.freeze
 
   before do
     @roll = DiceBag::Roll.new ROLL_DSTR

--- a/test/transform.rb
+++ b/test/transform.rb
@@ -46,4 +46,47 @@ describe DiceBag::Transform do
       _(@ast.first[1][:xdx][:count]).must_equal 1
     end
   end
+
+  describe 'with a target value' do
+    before do
+      tree = DiceBag::Parser.new.parse '5d6 t7'
+      @ast = DiceBag::Transform.new.apply tree
+    end
+
+    it 'must have a :targets key' do
+       _(@ast[1][:options].key?(:targets)).must_equal true
+    end
+
+    it ':targets key should be an Array' do
+      _(@ast[1][:options][:targets]).must_be_instance_of Array
+    end
+
+    it ':targets key contain our target' do
+      _(@ast[1][:options][:targets][0]).must_equal 7
+    end
+  end
+
+  describe 'with two target values' do
+    before do
+      tree = DiceBag::Parser.new.parse '5d6 t7 t10'
+      @ast = DiceBag::Transform.new.apply tree
+    end
+
+    it 'must have a :targets key' do
+       _(@ast[1][:options].key?(:targets)).must_equal true
+    end
+
+    it ':targets key should be an Array' do
+      _(@ast[1][:options][:targets]).must_be_instance_of Array
+    end
+
+    it ':targets key contain our first target' do
+      _(@ast[1][:options][:targets][0]).must_equal 7
+    end
+
+    it ':targets key contain our second target' do
+      _(@ast[1][:options][:targets][1]).must_equal 10
+    end
+  end
+
 end


### PR DESCRIPTION
This adds support to specify multiple targets for a roll.   This lets us more easily count up rolls for Exalted type systems.

Example:
[5d10 t7 t10] Roll: [10, 9, 8, 7, 1] Result: 5

t10 rolls: [10] = 1
t7 rolls: [10,9,8,7] = 4
result: 1 + 4 = 5